### PR TITLE
get stilt id without search

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -572,10 +572,10 @@ object is listed further below.
 Provide a string or list of strings representing a STILT station id's.
 
 #### id = DICT | LIST[DICT]
-provide a single dictionary, or a list of dictionaries. The dictionaires should be the result of a stiltstation.find() execution.
+provide a single dictionary, or a list of dictionaries. The dictionaries should be the result of a stiltstation.find() execution.
 
 #### progress = BOOL
-By default no progress bar is displayed while assembling the stiltstation object. With this keyword you can show/hide the progress bar. This parameter is only effective while providing id's. But
+By default no progress bar is displayed while assembling the stiltstation object. With this keyword you can show/hide the progress bar. This parameter is only effective while providing id's.
 
 	# return stilt stations based on stiltstation.find(id='STR')
     stiltstation.get('HTM')		    
@@ -585,7 +585,7 @@ By default no progress bar is displayed while assembling the stiltstation object
 	a = stiltstation.find(search='north')
 	stiltstation.get(a)
     OR
-	stiltstation.get(stiltstation.find(search='south))
+	stiltstation.get(stiltstation.find(search='south'))
 
 ### STILT Object
 classmethod **StiltStation(dict)**<br>

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -455,8 +455,9 @@ load the module with:
 
 Two functions are available: one to find STILT stations and one to extract the STILT station as 
 an object, which gives access to the data (time series and footprints).
+### stiltstation
 
-### stiltstation.find(\*\*kwargs)
+### .find(\*\*kwargs)
 This is the main function to find STILT stations. By default, it returns a dictionary where each 
 station id is the key to access metadata about the station. The order how you provide keywords 
 is respected and you can influence the result. Keyword arguments are applied sequentially (the 
@@ -541,6 +542,12 @@ Input format, see sdate,edate. Remember, that only year and month is checked.
 
 	stiltstation.find(dates=['2020-01-01', '2020/05/23'])
 
+#### progress = BOOL
+By default a progress bar is displayed while searching all possible STILT stations. With this keyword you can show/hide the progress bar.
+	
+	stiltstation.find(progress=True)   # DEFAULT, progress bar is displayed
+	stiltstation.find(progress=False)  # No progress bar
+	
 #### outfmt = 'STR'
 where string is `dict` | `pandas` | `list` | `map`.
 This keyword is ALWAYS executed last, regardless of the position within keyword arguments. By 
@@ -555,21 +562,30 @@ The map can be displayed directly in a Jupyter Notebook, or you can save the map
 	stiltstation.find(country='Italy', outfmt='pandas') 
 	stiltstation.find(country='Italy', outfmt='pandas').save('mymap.html')
 
-### stiltstation.get(id='')
+### .get(id='', progress=False)
 Returns a stilt station object or a list of stilt station objects. A stilt station object, 
 gives access to the underlying data (timeseries and footprints). You may provide a STR or
 LIST[STR] of STILT id's or the 'result' of a .find() query. The properties of the returned stilt 
 object is listed further below.
 
+#### id = STR | LIST[STR]
+Provide a string or list of strings representing a STILT station id's.
+
+#### id = DICT | LIST[DICT]
+provide a single dictionary, or a list of dictionaries. The dictionaires should be the result of a stiltstation.find() execution.
+
+#### progress = BOOL
+By default no progress bar is displayed while assembling the stiltstation object. With this keyword you can show/hide the progress bar. This parameter is only effective while providing id's. But
+
 	# return stilt stations based on stiltstation.find(id='STR')
     stiltstation.get('HTM')		    
-	stiltstation.get(['KIT','HTM150'])
+	stiltstation.get(['KIT','HTM150'], progress = True)
 
-	# return stilt stations based on dictionary or list of dict
+	# return stilt stations based on dictionary or list of dict with a progressbar
 	a = stiltstation.find(search='north')
 	stiltstation.get(a)
     OR
-	stiltstation.get(stiltstation.find(...))
+	stiltstation.get(stiltstation.find(search='south))
 
 ### STILT Object
 classmethod **StiltStation(dict)**<br>

--- a/icoscp/stilt/stiltstation.py
+++ b/icoscp/stilt/stiltstation.py
@@ -603,7 +603,7 @@ def get(id=None):
 
         if isinstance(id[0], str):
             # assuming we have a list of valid station id's
-            st = __get_stations([id])
+            st = __get_stations(id)
             if not st:
                 return None
             for s in st:

--- a/icoscp/stilt/stiltstation.py
+++ b/icoscp/stilt/stiltstation.py
@@ -11,11 +11,11 @@
 
 __credits__     = "ICOS Carbon Portal"
 __license__     = "GPL-3.0"
-__version__     = "0.1.0"
+__version__     = "0.1.1"
 __maintainer__  = "ICOS Carbon Portal, elaborated products team"
 __email__       = ['info@icos-cp.eu', 'claudio.donofrio@nateko.lu.se']
 __status__      = "rc1"
-__date__        = "2021-09-27"
+__date__        = "2021-11-04"
 
 import os
 import json
@@ -303,14 +303,22 @@ def __get_object(stations):
     return [StiltStation().get_info(stations[st]) for st in stations.keys()]
 
 
-def __get_all():
+def __get_stations(ids=[]):
     """ get all stilt stations available on the server
         return dictionary with meta data, keys are stilt station id's
     """
 
     # use directory listing from siltweb data
     allStations = os.listdir(CPC.STILTPATH)
+    
+    # if ids are provided, select only valid ids from allstations
+    if ids:
+        # make sure they are all upper case
+        ids = [i.upper() for i in ids]
+        #select only valid id from allstations
+        allStations = list(set(ids).intersection(allStations))
 
+        
     # add information on station name (and new STILT station id)
     # from stations.csv file used in stiltweb.
     # this is available from the backend through a url
@@ -497,7 +505,7 @@ def find(**kwargs):
         stations = kwargs['stations']
     else:
         # start with getting all stations
-        stations = __get_all()
+        stations = __get_stations()
 
     # with no keyword arguments, return all stations
     # in default format (see _outfmt())
@@ -575,27 +583,32 @@ def get(id=None):
     stationslist = []
 
     if isinstance(id,str):
-        st = find(id=id)
+        # assuming str is a station id
+        st = __get_stations(list(id))
         if not st:
             return None
         for s in st:
             stationslist.append(StiltStation(st[s]))
 
     if isinstance(id,dict):
+        # assuming dict is coming from .find....call
         for s in id:
             stationslist.append(StiltStation(id[s]))
 
     if isinstance(id, list):
         if isinstance(id[0],dict):
-           for s in id:
+            # assuming dict is coming from .find....call
+            for s in id:
                stationslist.append(StiltStation(id[s]))
 
         if isinstance(id[0], str):
-            st = find(id=id)
+            # assuming we have a list of valid station id's
+            st = __get_stations(list(id))
             if not st:
                 return None
             for s in st:
                 stationslist.append(StiltStation(st[s]))
+                
 
     if len(stationslist) == 1:
         return stationslist[0]

--- a/icoscp/stilt/stiltstation.py
+++ b/icoscp/stilt/stiltstation.py
@@ -584,7 +584,7 @@ def get(id=None):
 
     if isinstance(id,str):
         # assuming str is a station id
-        st = __get_stations(list(id))
+        st = __get_stations([id])
         if not st:
             return None
         for s in st:
@@ -603,7 +603,7 @@ def get(id=None):
 
         if isinstance(id[0], str):
             # assuming we have a list of valid station id's
-            st = __get_stations(list(id))
+            st = __get_stations([id])
             if not st:
                 return None
             for s in st:

--- a/icoscp/stilt/stiltstation.py
+++ b/icoscp/stilt/stiltstation.py
@@ -308,10 +308,6 @@ def __get_stations(ids=[], progress=True):
         return dictionary with meta data, keys are stilt station id's
     """
 
-    # invert the progress parameter, tqdm interpretation is
-    # DEUAULT disable = False -> progressbar is visible
-    progress != progress
-    
     # use directory listing from siltweb data
     allStations = os.listdir(CPC.STILTPATH)
     

--- a/icoscp/stilt/stiltstation.py
+++ b/icoscp/stilt/stiltstation.py
@@ -308,6 +308,10 @@ def __get_stations(ids=[], progress=True):
         return dictionary with meta data, keys are stilt station id's
     """
 
+    # invert the progress parameter, tqdm interpretation is
+    # DEUAULT disable = False -> progressbar is visible
+    progress = not progress
+    
     # use directory listing from siltweb data
     allStations = os.listdir(CPC.STILTPATH)
     

--- a/icoscp/stilt/stiltstation.py
+++ b/icoscp/stilt/stiltstation.py
@@ -332,6 +332,7 @@ def __get_stations(ids=[]):
     stations = {}
 
     # fill dictionary with ICOS station id, latitude, longitude and altitude
+	# implement progress True/False
     for ist in tqdm(sorted(allStations)):
         if not ist in df['STILT id'].values:
             continue

--- a/icoscp/stilt/stiltstation.py
+++ b/icoscp/stilt/stiltstation.py
@@ -592,7 +592,8 @@ def get(id=None, progress=False):
     progress: BOOL
             You can display a progressbar, for long running tasks. For
             example when you get a long list of id's. By default the
-            progressbar is not visible.
+            progressbar is not visible. This parameter is only applicable
+            while providing id's, but NOT for dictionaries.
             
     Returns
     -------

--- a/icoscp/stilt/stiltstation.py
+++ b/icoscp/stilt/stiltstation.py
@@ -309,7 +309,7 @@ def __get_stations(ids=[], progress=True):
     """
 
     # invert the progress parameter, tqdm interpretation is
-    # DEUAULT disable = False -> progressbar is visible
+    # DEFAULT disable = False -> progressbar is visible
     progress = not progress
     
     # use directory listing from siltweb data


### PR DESCRIPTION
- add a new keyword to stiltstation.find and stiltstation.get functions
progress = BOOL
The user can choose if a progressbar is visible or not while searching and extracting stiltstations.
By default with stiltstation.find() a progressbar is visible. Override with stiltstation.find(progress = False)
By default with stiltstation.get() a progressbar is NOT visible. Override with stiltstation.get(progress = True)
Documentation is updated (docs/modules.md) but not published.