### PR TITLE
report stilt usage

### DIFF
--- a/icoscp/stilt/__init__.py
+++ b/icoscp/stilt/__init__.py
@@ -5,11 +5,14 @@ to timeseries and spatial footprints.
 """
 
 import os
+import icoscp.const as CPC
 
-
-try:
-    os.stat('/data/')
-except FileNotFoundError as error:
-    print('Error! The Stilt module can only be used on ICOS servers and not '
-          'locally.\nExiting...')
-    exit(0)
+if not os.path.exists(CPC.STILTPATH):
+    print("""
+Please be aware, that the STILT module is not supported to run
+locally (outside of the Virtual Environment at the ICOS Carbon
+Portal). You must use one of our Jupyter Services.
+Visit https://www.icos-cp.eu/data-services/tools/jupyter-notebook
+for further information. Or you may use our online STILT viewer
+application https://stilt.icos-cp.eu/viewer/.
+    """)

--- a/icoscp/stilt/stiltobj.py
+++ b/icoscp/stilt/stiltobj.py
@@ -24,6 +24,8 @@ import json
 import xarray as xr
 import icoscp.const as CPC
 from icoscp.stilt import timefuncs as tf
+from icoscp import __version__ as release_version
+from icoscp import country
 ##############################################################################
 
 class StiltStation():
@@ -219,6 +221,8 @@ class StiltStation():
                 #Print message:
                 print("\033[0;31;1m Error...\nToo big STILT dataset!\nSelect data for a shorter time period.\n\n")
 
+        # track data usage
+        self.__portalUse()
         #Return dataframe:
         return df
     #----------------------------------------------------------------------------------------------------------
@@ -303,6 +307,8 @@ class StiltStation():
         fp.lon.attrs["axis"] = "X"
         fp.lon.attrs["standard_name"] = "longitude"
 
+        # track data usage
+        self.__portalUse()
         #Return footprint array:
         return fp
 
@@ -354,4 +360,19 @@ class StiltStation():
         #Return variable:
         return columns
 
+    def __portalUse(self):
+        """Assembles and posts stilt data usage."""
+
+        counter = {'StiltDataAccess': {
+            'params': {
+                'station_id': self.id,
+                'station_coordinates': {'latitude': self.lat,
+                                        'longitude': self.lon,
+                                        'altitude': self.alt},
+                'station_country': country.get(latlon=[self.lat, self.lon])['name']['common'],
+                'library': __name__,
+                'version': release_version,  # Grabbed from '__init__.py'.
+                'internal': True}}}
+        server = 'https://cpauth.icos-cp.eu/logs/portaluse'
+        requests.post(server, json=counter)
 # ----------------------------------- End of STILT Station Class ------------------------------------- #

--- a/icoscp/stilt/stiltobj.py
+++ b/icoscp/stilt/stiltobj.py
@@ -8,11 +8,11 @@
 
 __credits__     = "ICOS Carbon Portal"
 __license__     = "GPL-3.0"
-__version__     = "0.1.0"
+__version__     = "0.1.1"
 __maintainer__  = "ICOS Carbon Portal, elaborated products team"
 __email__       = ['info@icos-cp.eu']
-__status__      = "rc1"
-__date__        = "2021-04-23"
+__status__      = "release"
+__date__        = "2021-11-16"
 #################################################################################
 
 #Import modules
@@ -25,7 +25,6 @@ import xarray as xr
 import icoscp.const as CPC
 from icoscp.stilt import timefuncs as tf
 from icoscp import __version__ as release_version
-from icoscp import country
 ##############################################################################
 
 class StiltStation():
@@ -112,7 +111,7 @@ class StiltStation():
         hours : STR | INT, optional
             If hours is empty or None, ALL Timeslots are returned.
             [0,3,6,9,12,15,18,21]
-            
+
             Valid results are returned as result with LOWER BOUND values.
             For backwards compatibility, input for str format hh:mm is accepted
             Example:    hours = ["02:00",3,4] will return Timeslots for 0, 3
@@ -121,7 +120,7 @@ class StiltStation():
                         hours = ["10", "10:00", 10] returns timeslot 9
 
         columns : TYPE, optional
-            Valid entries are "default", "co2", "co", "rn", "wind", "latlon", "all"            
+            Valid entries are "default", "co2", "co", "rn", "wind", "latlon", "all"
             default (or empty) will return
             ["isodate","co2.stilt","co2.fuel","co2.bio", "co2.background"]
             A full description of the 'columns' can be found at
@@ -222,7 +221,7 @@ class StiltStation():
                 print("\033[0;31;1m Error...\nToo big STILT dataset!\nSelect data for a shorter time period.\n\n")
 
         # track data usage
-        self.__portalUse()
+        self.__portalUse('timeseries')
         #Return dataframe:
         return df
     #----------------------------------------------------------------------------------------------------------
@@ -245,7 +244,7 @@ class StiltStation():
         hours : STR | INT, optional
             If hours is empty or None, ALL Timeslots are returned.
             [0,3,6,9,12,15,18,21]
-            
+
             Valid results are returned as result with LOWER BOUND values.
             For backwards compatibility, input for str format hh:mm is accepted
             Example:    hours = ["02:00",3,4] will return Timeslots for 0, 3
@@ -308,7 +307,7 @@ class StiltStation():
         fp.lon.attrs["standard_name"] = "longitude"
 
         # track data usage
-        self.__portalUse()
+        self.__portalUse('footprint')
         #Return footprint array:
         return fp
 
@@ -360,8 +359,13 @@ class StiltStation():
         #Return variable:
         return columns
 
-    def __portalUse(self):
+    def __portalUse(self, dtype):
         """Assembles and posts stilt data usage."""
+
+        if not self.geoinfo:
+            country = 'unknown'
+        else:
+            country = self.geoinfo['name']['common']
 
         counter = {'StiltDataAccess': {
             'params': {
@@ -369,8 +373,9 @@ class StiltStation():
                 'station_coordinates': {'latitude': self.lat,
                                         'longitude': self.lon,
                                         'altitude': self.alt},
-                'station_country': country.get(latlon=[self.lat, self.lon])['name']['common'],
+                'station_country': country,
                 'library': __name__,
+                'data_type': dtype,
                 'version': release_version,  # Grabbed from '__init__.py'.
                 'internal': True}}}
         server = 'https://cpauth.icos-cp.eu/logs/portaluse'


### PR DESCRIPTION
- Add data format/schema to be reported back to rest-heart.
- Add call to '__portalUse' in 'get_ts()' and 'get_fp()' functions.