### PR TITLE
Added folium to `install_requires` in setup.py

### DIFF
--- a/icoscp.egg-info/requires.txt
+++ b/icoscp.egg-info/requires.txt
@@ -1,3 +1,4 @@
 pandas
 requests
 tqdm
+folium

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
 			'Documentation':'https://icos-carbon-portal.github.io/pylib/',
             'DataPortal':'https://data.icos-cp.eu/portal/',
             'SparqlEndpoint':'https://meta.icos-cp.eu/sparqlclient/?type=CSV'},
-    install_requires=['pandas','requests','tqdm'],
+    install_requires=['pandas','requests','tqdm', 'folium'],
     classifiers=[
         'Programming Language :: Python :: 3',
 		'Development Status :: 4 - Beta', 


### PR DESCRIPTION
Hello, 

Installing the latest version(0.1.14 ) of `icoscp` from PyPI I get

```
>>> from icoscp.station import station
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/private/tmp/test_icos/lib/python3.9/site-packages/icoscp/station/station.py", line 33, in <module>
    import icoscp.station.fmap as fmap
  File "/private/tmp/test_icos/lib/python3.9/site-packages/icoscp/station/fmap.py", line 25, in <module>
    import folium
ModuleNotFoundError: No module named 'folium'
>>>
```

To fix this I added `folium` to `setup.py`.

Thanks for the package by the way! We're currently using it as part of OpenGHG and it works really nicely.