### PR TITLE
ad stilt availability table

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -98,7 +98,7 @@ True if PID is set and found at the ICOS Carbon Portal
 All Dobj related metadata is available in the following properties.
 
 ### **Dobj.info**
-This will return a list of three pandas data frames which contain metadata.
+This will return a list of three Pandas DataFrames which contain metadata.
 ```
 info[0] -> information about the dobj like, url, specification, number of rows, related file name.
 info[1] -> information about the data like colName, value type, unit, kind
@@ -336,7 +336,7 @@ Load the module with:<br>
 	from icoscp.collection import collection
 
 classmethod **Collection(coll)**<br>
-(where `coll` represents a `pandas` data frame, similar to the output from .getIdList()). BUT 
+(where `coll` represents a `pandas.DataFrame`, similar to the output from .getIdList()). BUT 
 only similar. We do **NOT Recommend** to instantiate this class directly. Please **use** the 
 function **.get(CollectionId)**. The Purpose of the class documentation is to provide you a 
 list of attributes available, after the .get(CollectionId) return a collection object.
@@ -406,8 +406,8 @@ well  as creating an instance of a collection.
 
 	collection.getIdList()
 
-This will return a `pandas` data frame, listing all available collections at the data portal. The 
-data frame contains the following columns: 
+This will return a `pandas.DataFrame`, listing all available collections at the data portal. The 
+DataFrame contains the following columns: 
 `['collection', 'doi', 'title', 'description', 'dobj', 'count']`. We would recommend that you 
 pay close attention to the `count`. We have collections with many data objects associated. If 
 you just want to play around, select a collection with less than 10 objects.
@@ -418,7 +418,7 @@ Example: .get('https://meta.icos-cp.eu/collections/n7cIMHIyqHJKBeF_3jjgptHP')
 - `dobj` contains a list (LIST[STR]) of all PID/URI associated data objects.<br>
 - `count` tells you how many data objects are associated with this collection.
 <br><br>
-- Returns a pandas data frame 
+- Returns a pandas DataFrame 
 
 #### collection.get()
 
@@ -494,6 +494,9 @@ STILT stations with geolocation in Norway you can search for either NO, NOR, Nor
 
 	stiltstation.find(country=['Swe','norge', 'IT'])
 
+##### project='icos'
+This option will retrieve all STILT stations that are ICOS stations.
+
 ##### bbox=[(lat,lon),(lat,lon)]
 Bounding Box. Provide two tuples (wgs84), where the box is defined as TopLeftCorner (NorthWest) 
 and BottomRightCorner (SouthEast). The following example returns approximately all stations in 
@@ -549,18 +552,21 @@ By default a progress bar is displayed while searching all possible STILT statio
 	stiltstation.find(progress=False)  # No progress bar
 	
 #### outfmt = 'STR'
-where string is `dict` | `pandas` | `list` | `map`.
+where string is `dict` | `pandas` | `list` | `map` | `avail`.
 This keyword is ALWAYS executed last, regardless of the position within keyword arguments. By 
-default, a `dictionary` is returned. With `pandas` a pandas data frame is returned where the 
+default, a `dictionary` is returned. With `pandas` a pandas DataFrame is returned where the 
 station id is indexed, each row contains one station with the same metadata as is available in 
 the dictionary [https://pandas.pydata.org/docs/](https://pandas.pydata.org/docs/). List however 
 returns a list of STILT station objects. Please see the documentation about<br>
-`stiltstation.get(id="")`. Lastly you can choose `map`, which returns a folium map 
+`stiltstation.get(id="")`. The choice `map`, returns a folium map 
 [https://python-visualization.github.io/folium/](https://python-visualization.github.io/folium/).
 The map can be displayed directly in a Jupyter Notebook, or you can save the map to a html file.
 
 	stiltstation.find(country='Italy', outfmt='pandas') 
 	stiltstation.find(country='Italy', outfmt='pandas').save('mymap.html')
+
+Finally, the choice `avail` will return a pandas DataFrame where availability of timeseries data 
+per STILT station is gathered for each year. 
 
 ### .get(id='', progress=False)
 Returns a stilt station object or a list of stilt station objects. A stilt station object, 
@@ -630,7 +636,7 @@ Dictionary with geographical (country) information, if the station is within a c
 
 #### .get_ts(start_date, end_date, hours=[], columns=''):
 STILT concentration time series for a given time period, with optional selection of specific 
-hours and columns. Returns time series as a `pandas` data frame.
+hours and columns. Returns time series as a `pandas.DataFrame`.
 
 - start_date : STR, FLOAT/INT (Unix timestamp), datetime object
 	- start_date = '2018-01-01'

--- a/icoscp/stilt/stiltstation.py
+++ b/icoscp/stilt/stiltstation.py
@@ -559,8 +559,10 @@ def find(**kwargs):
         Remember, that only year and month is checked.
     Example: station.find(dates=['2020-01-01', '2020/05/23'])
 
-    project STR 'icos':
+    project STR 'icos'.
         This will only return stilt stations that are ICOS stations.
+    Example: station.find(project='icos')
+
         
     progress BOOL 
         By default progress is set to True, which returns a progressbar

--- a/icoscp/stilt/stiltstation.py
+++ b/icoscp/stilt/stiltstation.py
@@ -562,7 +562,6 @@ def find(**kwargs):
     project STR 'icos'.
         This will only return stilt stations that are ICOS stations.
     Example: station.find(project='icos')
-
         
     progress BOOL 
         By default progress is set to True, which returns a progressbar

--- a/icoscp/stilt/stiltstation.py
+++ b/icoscp/stilt/stiltstation.py
@@ -311,21 +311,30 @@ def _avail(stations):
 
     for stn in stations:
         avail_per_stn ={}
+        if stations[stn]['icos']: 
+            avail_per_stn['ICOS id'] = stations[stn]['icos']['stationId']
+        else: 
+            avail_per_stn['ICOS id'] = ''
+        if stations[stn]['alt'] != None: 
+            avail_per_stn['Alt'] = stations[stn]['alt']
+        else: 
+            avail_per_stn['Alt'] = 0
         if stations[stn]['years'] != None:
             years_set = years_set.union(stations[stn]['years'])
             for y in stations[stn]['years']:
                 avail_per_stn[int(y)] = int(stations[stn][y]['nmonths'])
         availability[stn] = avail_per_stn
-
-    columns_list = list(range(min ({int(x) for x in years_set}),
+    
+    year_list = list(range(min ({int(x) for x in years_set}),
                               max ({int(x) for x in years_set}) + 1 ))
+    columns_list = ['Alt'] + year_list + ['ICOS id']
       
     df = pd.DataFrame(data = list(availability[x] for x in availability.keys()), 
                       index = list(availability.keys()), 
                       columns = columns_list)
     # Fill in the gaps.
-    df.fillna(0,inplace=True)
-    df.applymap(np.int16)
+    df[year_list] = df[year_list].fillna(0)
+    df[['Alt'] + year_list] = df[['Alt'] + year_list].applymap(np.int64)
 
     return df
 

--- a/icoscp/stilt/stiltstation.py
+++ b/icoscp/stilt/stiltstation.py
@@ -86,7 +86,7 @@ def _outfmt(kwargs, stations):
         fmt = 'dict'
     
     # make sure we have a valid keyword, else set default dict
-    valid = ['dict', 'list', 'pandas', 'map']
+    valid = ['dict', 'list', 'pandas', 'map', 'avail']
     if not fmt in valid:
             fmt = 'dict'
     
@@ -104,6 +104,9 @@ def _outfmt(kwargs, stations):
 
     if fmt == 'map':
         return fmap.get(stations)
+
+    if fmt == 'avail':
+        return _avail(stations)
 
 def _country(kwargs, stations):
     """
@@ -282,6 +285,49 @@ def _edate(kwargs, stations):
 
     stations =  {k: stations[k] for k in flt}
     return stations
+
+
+def _project(kwargs, stations):
+
+    proj = kwargs['project']
+    
+    # We use lowercase. 
+    proj = proj.lower()
+
+    flt = []
+    if proj == 'icos':
+        for k in stations:
+            if stations[k]['icos']:
+                flt.append(k)
+
+    stations =  {k: stations[k] for k in flt}
+    return stations
+
+
+def _avail(stations):
+    
+    years_set = set()
+    availability = {}
+
+    for stn in stations:
+        avail_per_stn ={}
+        if stations[stn]['years'] != None:
+            years_set = years_set.union(stations[stn]['years'])
+            for y in stations[stn]['years']:
+                avail_per_stn[int(y)] = int(stations[stn][y]['nmonths'])
+        availability[stn] = avail_per_stn
+
+    columns_list = list(range(min ({int(x) for x in years_set}),
+                              max ({int(x) for x in years_set}) + 1 ))
+      
+    df = pd.DataFrame(data = list(availability[x] for x in availability.keys()), 
+                      index = list(availability.keys()), 
+                      columns = columns_list)
+    # Fill in the gaps.
+    df.fillna(0,inplace=True)
+    df.applymap(np.int16)
+
+    return df
 
 
 def _search(kwargs, stations):
@@ -504,11 +550,14 @@ def find(**kwargs):
         Remember, that only year and month is checked.
     Example: station.find(dates=['2020-01-01', '2020/05/23'])
 
+    project STR 'icos':
+        This will only return stilt stations that are ICOS stations.
+        
     progress BOOL 
         By default progress is set to True, which returns a progressbar
         while searching the catalogue of STILT stations.    
     
-    outfmt STR ['dict'| 'pandas' | 'list' | 'map']:
+    outfmt STR ['dict'| 'pandas' | 'list' | 'map'| 'avail']:
         the result is returned as
         
             dict:       dictionary with full metadata for each station
@@ -517,6 +566,9 @@ def find(**kwargs):
             list:       list of stilt station objects
             map:        folium map, can be displayed directly in notebooks
                         or save to a static (leaflet) .html webpage
+            avail:      This choice will return availability of time series 
+                        data for all stilt stations. 
+                        Output format is a pandas dataframe.
     
     Returns
     -------
@@ -565,7 +617,8 @@ def find(**kwargs):
            'edate':_edate,
            'dates':_dates,
            'daterange':__daterange,
-           'search':_search}
+           'search':_search,
+           'project':_project}
 
     for k in kwargs.keys():
         if k in fun.keys():
@@ -650,4 +703,3 @@ def get(id=None, progress=False):
         return stationslist[0]
     else:
         return stationslist
-


### PR DESCRIPTION
Tested on jupyterLab. 
- new filter: stiltstation.find( project = 'icos')
- new outfmt: stiltstation.find( outfmt = 'avail')   
the output format for the availability table is a dataframe. 