### PR TITLE
find stilt stations, exclude .zip files

### DIFF
--- a/src/icoscp/stilt/stiltstation.py
+++ b/src/icoscp/stilt/stiltstation.py
@@ -461,6 +461,10 @@ def __get_stations(ids=None, progress=True):
         # set years and month of available data
         years = [y for y in os.listdir(CPC.STILTPATH + '/' + ist) if
                  os.path.exists(CPC.STILTPATH + '/' + ist + '/' + y)]
+        
+        # for atmo access zip files may exist  for download. we need to exclude them
+        years = [y for y in years if not y.endswith('.zip')]
+        
         stations[ist]['years'] = years
         for yy in sorted(stations[ist]['years']):
             stations[ist][yy] = {}


### PR DESCRIPTION
exclude zip files in the stiltweb data structure
For AtmoAccess a new download procedure was defined, which adds per year zip files into the data structure. We need to exclude them while filtering for the years per station.