### PR TITLE
Drop pandas version cap and remove folium Stamen tiles

### DIFF
--- a/icoscp/pyproject.toml
+++ b/icoscp/pyproject.toml
@@ -39,7 +39,7 @@ requires-python = ">=3.10"
 dependencies = [
     "folium >= 0.13.0",
     "icoscp_core",
-    "pandas >= 1.3.5, <= 2.2.3",
+    "pandas >= 1.3.5",
     "requests >= 2.26.0",
     "tqdm >= 4.64.1"
 ]

--- a/icoscp/src/icoscp/collection/collection.py
+++ b/icoscp/src/icoscp/collection/collection.py
@@ -111,10 +111,10 @@ class Collection():
     
     def __set__(self, coll):
         
-        self._id = coll.collection.values[0]
-        self._doi = coll.doi.values[0]
-        self._title = coll.title.values[0]
-        self._description = coll.description.values[0]
+        self._id = coll.collection.iloc[0]
+        self._doi = coll.doi.iloc[0]
+        self._title = coll.title.iloc[0]
+        self._description = coll.description.iloc[0]
         
         # get data objects for the collection
          

--- a/icoscp/src/icoscp/station/fmap.py
+++ b/icoscp/src/icoscp/station/fmap.py
@@ -73,8 +73,8 @@ def get(queried_stations, project, icon):
     add_tile_layers(stations_map)
     # Use the stations at the most southwest and northeast locations
     # and bind the map within these stations.
-    sw_loc = stations[['lat', 'lon']].dropna(axis=0).min().values.tolist()
-    ne_loc = stations[['lat', 'lon']].dropna(axis=0).max().values.tolist()
+    sw_loc = stations[['lat', 'lon']].dropna(axis=0).min().to_numpy().tolist()
+    ne_loc = stations[['lat', 'lon']].dropna(axis=0).max().to_numpy().tolist()
     stations_map.fit_bounds([sw_loc, ne_loc])
     stations = stations.transpose()
     for station_index in stations:

--- a/icoscp/src/icoscp/station/fmap.py
+++ b/icoscp/src/icoscp/station/fmap.py
@@ -272,9 +272,6 @@ def add_tile_layers(folium_map):
     # Add built-in tile layers.
     folium_map.add_child(folium.TileLayer('cartodbpositron'))
     folium_map.add_child(folium.TileLayer('cartodbdark_matter'))
-    folium_map.add_child(folium.TileLayer('stamenwatercolor'))
-    folium_map.add_child(folium.TileLayer('stamentoner'))
-    folium_map.add_child(folium.TileLayer('stamenterrain'))
     # Add another layer with satellite images from ESRI.
     folium_map.add_child(folium.TileLayer(
         tiles='https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer'

--- a/icoscp/src/icoscp/station/station.py
+++ b/icoscp/src/icoscp/station/station.py
@@ -455,7 +455,7 @@ class Station:
             self._products = pd.DataFrame(p)
 
             # replace samplingheight=None with empty string
-            self._data.samplingheight.replace(to_replace=[None], value="", inplace=True)
+            self._data['samplingheight'] = self._data['samplingheight'].replace(to_replace=[None], value="")
         else:
             self._products = 'no data available'
 
@@ -574,7 +574,7 @@ def get(stationId: str = None,
         return my_stn
 
     # we have found a valid id
-    my_stn.stationId = stn.id.values[0]
+    my_stn.stationId = stn.id.iloc[0]
     my_stn.valid = True
 
     # it is possible that more than one station has the same id
@@ -591,11 +591,11 @@ def get(stationId: str = None,
             my_stn.eas = float(stn.elevation[stn.project.str.upper() == 'ICOS'])
     else:
         if stn.lat.any():
-            my_stn.lat = float(stn.lat.values[0])
+            my_stn.lat = float(stn.lat.iloc[0])
         if stn.lon.any():
-            my_stn.lon = float(stn.lon.values[0])
+            my_stn.lon = float(stn.lon.iloc[0])
         if stn.elevation.any():
-            my_stn.eas = float(stn.elevation.values[0])
+            my_stn.eas = float(stn.elevation.iloc[0])
 
     my_stn.name = stn.name.iloc[0]
     my_stn.country = stn.country.iloc[0]
@@ -608,12 +608,12 @@ def get(stationId: str = None,
     # flow from the thematic centres is achieved.
 
     if 'ICOS' in my_stn.project:
-        my_stn.theme = stn.stationTheme.values[0].split('/')[-1]
-        my_stn.icosclass = stn.icosClass.values[0]
-        my_stn.firstName = stn.firstName.values[0]
-        my_stn.lastName = stn.lastName.values[0]
-        my_stn.email = stn.email.values[0]
-        my_stn.siteType = stn.siteType.values[0]
+        my_stn.theme = stn.stationTheme.iloc[0].split('/')[-1]
+        my_stn.icosclass = stn.icosClass.iloc[0]
+        my_stn.firstName = stn.firstName.iloc[0]
+        my_stn.lastName = stn.lastName.iloc[0]
+        my_stn.email = stn.email.iloc[0]
+        my_stn.siteType = stn.siteType.iloc[0]
 
     return my_stn
 
@@ -715,7 +715,7 @@ def _get_id_list(filter: dict = {'project': 'ICOS', 'theme': ['AS', 'ES', 'OS']}
 
     query = sparqls.station_query(filter=filter)
     stn_df = RunSparql(query, 'pandas').run()
-    stn_df.drop_duplicates(inplace=True)
+    stn_df = stn_df.drop_duplicates()
 
     if not isinstance(stn_df, pd.DataFrame):
         return stn_df
@@ -727,7 +727,7 @@ def _get_id_list(filter: dict = {'project': 'ICOS', 'theme': ['AS', 'ES', 'OS']}
     stn_df['theme'] = stn_df.apply(lambda x: x['stationTheme'].split('/')[-1], axis=1)
 
     # Sort queried stations by the given sort argument if any.
-    stn_df.sort_values(by=sort, inplace=True, ignore_index=True)
+    stn_df = stn_df.sort_values(by=sort, ignore_index=True)
 
     if outfmt == 'pandas':
         return stn_df

--- a/icoscp_stilt/pyproject.toml
+++ b/icoscp_stilt/pyproject.toml
@@ -38,7 +38,7 @@ requires-python = ">=3.10"
 dependencies = [
     "folium >= 0.13.0",
     "icoscp_core",
-    "pandas >= 1.3.5, <= 2.2.3",
+    "pandas >= 1.3.5",
     "netCDF4 >= 1.5.8",
     "requests >= 2.26.0",
     "tqdm >= 4.64.1",

--- a/icoscp_stilt/src/icoscp_stilt/fmap.py
+++ b/icoscp_stilt/src/icoscp_stilt/fmap.py
@@ -50,8 +50,6 @@ def get(stations, fmt='map', cluster=True):
     
     folium.TileLayer('openstreetmap').add_to(myMap)
     folium.TileLayer('cartodbpositron').add_to(myMap)
-    folium.TileLayer('stamentoner').add_to(myMap)
-    folium.TileLayer('stamenterrain').add_to(myMap)
     
     markers = []    # keep all the markers for clustering
     lats = []       # keep lat, lon vector to calculate the center of the map

--- a/icoscp_stilt/src/icoscp_stilt/stiltobj.py
+++ b/icoscp_stilt/src/icoscp_stilt/stiltobj.py
@@ -151,7 +151,7 @@ class StiltStation():
         new_range = []
         # Create a pandas dataframe containing one column of datetime
         # objects with 3-hour intervals:
-        date_range = pd.date_range(s_date, e_date, freq='3H')
+        date_range = pd.date_range(s_date, e_date, freq='3h')
         # Loop through every Datetime object in the dataframe and
         # generate a list of Datetime objects for the STILT results
         # that exist.
@@ -185,12 +185,12 @@ class StiltStation():
                 output = np.asarray(http_resp.json())
                 # Convert numpy array with STILT results to a pandas dataframe
                 df = pd.DataFrame(output[:, :], columns=columns)
-                df = df.replace('null', np.NaN)
+                df = df.replace('null', np.nan)
                 df = df.astype(float)
                 # Convert 'date' column to a Datetime Object type.
                 df['date'] = pd.to_datetime(df['isodate'], unit='s')
                 # Set 'date'-column as index:
-                df.set_index(['date'], inplace=True)
+                df = df.set_index(['date'])
                 # Filter dataframe values by timeslots:
                 hours = [str(h).zfill(2) for h in hours]
                 df = df.loc[df.index.strftime('%H').isin(hours)]
@@ -259,7 +259,7 @@ class StiltStation():
             return False
 
         # Create a pandas dataframe containing one column of datetime objects with 3-hour intervals:
-        date_range = pd.date_range(start_date, end_date, freq='3H')
+        date_range = pd.date_range(start_date, end_date, freq='3h')
 
         # Filter date_range by timeslots:
         date_range = [t for t in date_range if int(t.strftime('%H')) in hours]
@@ -358,7 +358,7 @@ class StiltStation():
             df = pd.DataFrame(output[:, :], columns=cols)
 
             # Replace 'null'-values with numpy NaN-values:
-            df = df.replace('null', np.NaN)
+            df = df.replace('null', np.nan)
 
             # Set dataframe data type to float:
             df = df.astype(float)
@@ -368,7 +368,7 @@ class StiltStation():
                 df['isodate'] = pd.to_datetime(df['isodate'], unit='s')
 
                 # Set 'date'-column as index:
-                df.set_index(['date'], inplace=True)
+                df = df.set_index(['date'])
 
         # track data usage
         self.__portalUse('timeseries')

--- a/icoscp_stilt/src/icoscp_stilt/stiltstation.py
+++ b/icoscp_stilt/src/icoscp_stilt/stiltstation.py
@@ -91,7 +91,7 @@ def _outfmt(kwargs, stations):
         return stations
 
     if fmt == 'pandas':
-        df = pd.DataFrame().from_dict(stations)
+        df = pd.DataFrame.from_dict(stations)
         return df.transpose()
 
     if fmt == 'list':
@@ -292,14 +292,14 @@ def _avail(stations):
                       columns=columns_list)
     # Fill in the gaps.
     df[year_list] = df[year_list].fillna(0)
-    df[['Alt'] + year_list] = df[['Alt'] + year_list].applymap(int)
+    df[['Alt'] + year_list] = df[['Alt'] + year_list].map(int)
 
     # convert alt to string, so that we can remove nan values
     df['ICOS alt'] = df['ICOS alt'].astype(str)
     df['ICOS alt'] = df['ICOS alt'].str.replace('nan', '')
 
     # sort by StiltStation id
-    df.sort_index(inplace=True)
+    df = df.sort_index()
     return df
 
 


### PR DESCRIPTION
- Remove the `pandas <= 2.2.3` upper bound in both `icoscp` and `icoscp_stilt` so the libraries install cleanly against current pandas releases.
- Replace pandas APIs that were deprecated or removed in pandas 3.x: switch `.values[0]` to `.iloc[0]`, replace `.values.tolist()` with `.to_numpy().tolist()`, drop `inplace=True` in favor of reassignment for `replace`, `set_index`, `sort_values`, `sort_index` and `drop_duplicates`, rename the `'3H'` frequency alias to `'3h'`, swap `applymap` for `map`, use `np.nan` instead of the removed `np.NaN`, and fix the `pd.DataFrame().from_dict(...)` misuse.
- Remove Folium Stamen tile layers (`stamenwatercolor`, `stamentoner`, `stamenterrain`) from the station and STILT maps since Stamen tiles are no longer served through Folium's built-in shortcuts. 